### PR TITLE
Remove extra `board` dependency

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 RPi.GPIO~=0.7
 smbus2~=0.4
 ovos_utils~=0.0.25
-board~=1.0
+# board~=1.0
 click~=8.0
 click-default-group~=1.2
 rpi_ws281x~=4.3

--- a/sj201_interface/led/__init__.py
+++ b/sj201_interface/led/__init__.py
@@ -43,9 +43,9 @@
 import abc
 from typing import Union
 
-import board
 import neopixel
 
+from adafruit_blinka.microcontroller.bcm283x.pin import D12
 from enum import Enum
 from time import sleep
 from threading import Thread, Event
@@ -254,7 +254,7 @@ class R10Led(MycroftLed):
         # order = neopixel.GRB
         self.brightness = 0.2
         self.pixels = neopixel.NeoPixel(
-            board.D12,
+            D12,
             self.real_num_leds,
             brightness=self.brightness,
             auto_write=False,


### PR DESCRIPTION
# Description
Removes `board` dependency which was just wrapping an import from `adafruit-blinka`

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
debos images were failing previously and this change resolved the issues seen there