### PR TITLE
Loosen ovos-utils dependency spec

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 RPi.GPIO~=0.7
 smbus2~=0.4
-ovos_utils~=0.0.25
+ovos_utils~=0.0,>=0.0.25
 # board~=1.0
 click~=8.0
 click-default-group~=1.2


### PR DESCRIPTION
# Description
Allow installation with newer ovos-utils

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
@builderjer I noticed this was being patched in raspovos so you should be able to pip install normally with this change